### PR TITLE
Allow user to specify a density or Wigner-Seitz radius in supercell creation

### DIFF
--- a/malada/providers/supercell.py
+++ b/malada/providers/supercell.py
@@ -66,16 +66,20 @@ class SuperCellProvider(Provider):
         units_density="g/(cm^3)",
     ):
 
-        if compression_factor is None and density is None and radius is None:
+        if sum([compression_factor is None, density is None, radius is None]) == 3:
             raise ValueError(
                 "At least one of compression_factor, density and radius must be speficied"
             )
-        elif density is not None:
+        elif sum([compression_factor is None, density is None, radius is None]) < 2:
+            print("Warning: More than one of compression factor, density, "
+                  "and radius is specified.\nRadius takes first priority, "
+                  "then density, finally compression factor.")
+        if density is not None:
             density_ambient = SuperCellProvider.get_mass_density(
                 supercell, unit=units_density
             )
             compression_factor = (density_ambient / density) ** (1.0 / 3.0)
-        elif radius is not None:
+        if radius is not None:
             radius_ambient = SuperCellProvider.get_wigner_seitz_radius(supercell)
             compression_factor = radius / radius_ambient
 

--- a/malada/providers/supercell.py
+++ b/malada/providers/supercell.py
@@ -56,9 +56,29 @@ class SuperCellProvider(Provider):
             print("Getting <<supercell>>.vasp file from disc.")
 
     @staticmethod
-    def get_compressed_cell(supercell, compression_factor):
-        supercell.set_cell(supercell.get_cell() * compression_factor,
-                           scale_atoms=True)
+    def get_compressed_cell(
+        supercell,
+        compression_factor=None,
+        density=None,
+        radius=None,
+        units_density="g_cm^3",
+    ):
+
+        if compression_factor is None and density is None and radius is None:
+            raise ValueError(
+                "At least one of compression_factor, density and radius must be speficied"
+            )
+        elif density is not None:
+            density_ambient = SuperCellProvider.get_mass_density(
+                supercell, unit=units_density
+            )
+            compression_factor = (density_ambient / density) ** (1.0 / 3.0)
+        elif radius is not None:
+            radius_ambient = SuperCellProvider.get_wigner_seitz_radius(supercell)
+            compression_factor = radius / radius_ambient
+
+        supercell.set_cell(supercell.get_cell() * compression_factor, scale_atoms=True)
+
         return supercell
 
     @staticmethod
@@ -102,5 +122,3 @@ class SuperCellProvider(Provider):
             return mass_density
         else:
             raise Exception("Unit not implemented")
-
-

--- a/malada/providers/supercell.py
+++ b/malada/providers/supercell.py
@@ -63,7 +63,7 @@ class SuperCellProvider(Provider):
         compression_factor=None,
         density=None,
         radius=None,
-        units_density="g_cm^3",
+        units_density="g/(cm^3)",
     ):
 
         if compression_factor is None and density is None and radius is None:
@@ -108,7 +108,7 @@ class SuperCellProvider(Provider):
         return rs_angstrom / Bohr
 
     @staticmethod
-    def get_mass_density(supercell, unit="g_cm^3"):
+    def get_mass_density(supercell, unit="g/(cm^3)"):
         nr_atoms = len(supercell)
         mass_atom = supercell[0].mass
         mass_atoms = nr_atoms * mass_atom
@@ -118,7 +118,7 @@ class SuperCellProvider(Provider):
         u_angstrom3_in_g_cm3 = u_angstrom3_in_kg_m3 * 1000
         if unit == "kg_m^3":
             return mass_density/u_angstrom3_in_kg_m3
-        elif unit == "g_cm^3":
+        elif unit == "g/(cm^3)":
             return mass_density/u_angstrom3_in_g_cm3
         elif unit == "u_Angstrom^3":
             return mass_density

--- a/malada/providers/supercell.py
+++ b/malada/providers/supercell.py
@@ -48,7 +48,9 @@ class SuperCellProvider(Provider):
             super_cell = ase.build.make_supercell(primitive_cell,
                                                   transformation_matrix)
             super_cell = self.get_compressed_cell(super_cell,
-                                                  self.parameters.compression)
+                                                  compression_factor = self.parameters.compression,
+                                                  density = self.parameters.mass_density,
+                                                  radius = self.parameters.WS_radius)
             ase.io.write(self.supercell_file,
                          super_cell, format="vasp", long_format=True)
         else:
@@ -122,3 +124,5 @@ class SuperCellProvider(Provider):
             return mass_density
         else:
             raise Exception("Unit not implemented")
+
+

--- a/malada/providers/supercell.py
+++ b/malada/providers/supercell.py
@@ -48,7 +48,7 @@ class SuperCellProvider(Provider):
             super_cell = ase.build.make_supercell(primitive_cell,
                                                   transformation_matrix)
             super_cell = self.get_compressed_cell(super_cell,
-                                                  compression_factor = self.parameters.compression,
+                                                  stretch_factor = self.parameters.stretch_factor,
                                                   density = self.parameters.mass_density,
                                                   radius = self.parameters.WS_radius)
             ase.io.write(self.supercell_file,
@@ -60,30 +60,30 @@ class SuperCellProvider(Provider):
     @staticmethod
     def get_compressed_cell(
         supercell,
-        compression_factor=None,
+        stretch_factor=None,
         density=None,
         radius=None,
         units_density="g/(cm^3)",
     ):
 
-        if sum([compression_factor is None, density is None, radius is None]) == 3:
+        if sum([stretch_factor is None, density is None, radius is None]) == 3:
             raise ValueError(
-                "At least one of compression_factor, density and radius must be speficied"
+                "At least one of stretch_factor, density and radius must be speficied"
             )
-        elif sum([compression_factor is None, density is None, radius is None]) < 2:
-            print("Warning: More than one of compression factor, density, "
+        elif sum([stretch_factor is None, density is None, radius is None]) < 2:
+            print("Warning: More than one of stretch factor, density, "
                   "and radius is specified.\nRadius takes first priority, "
-                  "then density, finally compression factor.")
+                  "then density, finally stretch factor.")
         if density is not None:
             density_ambient = SuperCellProvider.get_mass_density(
                 supercell, unit=units_density
             )
-            compression_factor = (density_ambient / density) ** (1.0 / 3.0)
+            stretch_factor = (density_ambient / density) ** (1.0 / 3.0)
         if radius is not None:
             radius_ambient = SuperCellProvider.get_wigner_seitz_radius(supercell)
-            compression_factor = radius / radius_ambient
+            stretch_factor = radius / radius_ambient
 
-        supercell.set_cell(supercell.get_cell() * compression_factor, scale_atoms=True)
+        supercell.set_cell(supercell.get_cell() * stretch_factor, scale_atoms=True)
 
         return supercell
 

--- a/malada/utils/parameters.py
+++ b/malada/utils/parameters.py
@@ -114,7 +114,9 @@ class Parameters:
     def __init__(self):
         # General information about the system.
         self.temperature = 0
-        self.compression = 1
+        self.compression = None
+        self.mass_density = None
+        self.WS_radius = None
         self.number_of_atoms = 0
         self.crystal_structure = "bcc"
         self.element = None

--- a/malada/utils/parameters.py
+++ b/malada/utils/parameters.py
@@ -114,7 +114,7 @@ class Parameters:
     def __init__(self):
         # General information about the system.
         self.temperature = 0
-        self.compression = None
+        self.stretch_factor = None
         self.mass_density = None
         self.WS_radius = None
         self.number_of_atoms = 0


### PR DESCRIPTION
This PR addresses issue #19.

Previously, to change the density of the supercell, the user had to specify a compression_factor. Now, they can instead specify a mass density or Wigner-Seitz radius, which is more intuitive. There is a check that at least one of `compression_factor`, `density`, and `radius` is specified.