### PR TITLE
Automatically download CIF files in SuperCellProvider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ temp/
 *.egg-info
 *.pyc
 *.npy
+.mp_api/
 examples/ex*/
 examples/develop*/
 examples/develop.py

--- a/malada/providers/supercell.py
+++ b/malada/providers/supercell.py
@@ -1,5 +1,4 @@
 """Provider for creation of supercell from crystal structure."""
-
 from malada.utils import structure_to_transformation
 from .provider import Provider
 import os
@@ -38,14 +37,8 @@ class SuperCellProvider(Provider):
         cif_file : string
             Path to cif file used for supercell creation.
         """
-        file_name = (
-            self.parameters.element
-            + "_"
-            + str(self.parameters.number_of_atoms)
-            + "_"
-            + self.parameters.crystal_structure
-            + ".vasp"
-        )
+        file_name = self.parameters.element + "_" + str(self.parameters.number_of_atoms) \
+                    + "_" + self.parameters.crystal_structure + ".vasp"
         self.supercell_file = os.path.join(provider_path, file_name)
         if self.external_supercell_file is None:
             try:
@@ -53,9 +46,8 @@ class SuperCellProvider(Provider):
             except FileNotFoundError:
                 self.generate_cif(cif_file)
                 primitive_cell = ase.io.read(cif_file, format="cif")
-            transformation_matrix = structure_to_transformation[
-                self.parameters.crystal_structure
-            ][self.parameters.number_of_atoms]
+
+            transformation_matrix = self.get_transformation_matrix(cif_file)
 
             super_cell = ase.build.make_supercell(primitive_cell, transformation_matrix)
             super_cell = self.get_compressed_cell(
@@ -79,6 +71,7 @@ class SuperCellProvider(Provider):
         radius=None,
         units_density="g/(cm^3)",
     ):
+
         if sum([stretch_factor is None, density is None, radius is None]) == 3:
             raise ValueError(
                 "At least one of stretch_factor, density and radius must be speficied"
@@ -109,21 +102,20 @@ class SuperCellProvider(Provider):
         nr_electrons = 0
         for i in range(0, nr_atoms):
             nr_electrons += supercell[i].number
-        number_density = nr_electrons / volume_atoms
+        number_density = nr_electrons/volume_atoms
         angstrom3_in_m3 = 1 / (m * m * m)
         angstrom3_in_cm3 = angstrom3_in_m3 * 1000000
         if unit == "Angstrom^3":
             return number_density
         elif unit == "cm^3":
-            return number_density / angstrom3_in_cm3
+            return number_density/angstrom3_in_cm3
         else:
             raise Exception("Unit not implemented")
 
     @staticmethod
     def get_wigner_seitz_radius(supercell):
-        number_density = SuperCellProvider.get_number_density(
-            supercell, unit="Angstrom^3"
-        )
+        number_density = SuperCellProvider.\
+            get_number_density(supercell, unit="Angstrom^3")
         rs_angstrom = (3 / (4 * np.pi * number_density)) ** (1 / 3)
         return rs_angstrom / Bohr
 
@@ -137,9 +129,9 @@ class SuperCellProvider(Provider):
         u_angstrom3_in_kg_m3 = kg / (m * m * m)
         u_angstrom3_in_g_cm3 = u_angstrom3_in_kg_m3 * 1000
         if unit == "kg_m^3":
-            return mass_density / u_angstrom3_in_kg_m3
+            return mass_density/u_angstrom3_in_kg_m3
         elif unit == "g/(cm^3)":
-            return mass_density / u_angstrom3_in_g_cm3
+            return mass_density/u_angstrom3_in_g_cm3
         elif unit == "u_Angstrom^3":
             return mass_density
         else:
@@ -201,3 +193,42 @@ class SuperCellProvider(Provider):
         )
         # write to the cif file
         structure.to(filename=cif_file)
+
+    def get_transformation_matrix(self, cif_file):
+        # extract the number of atoms in the unit cell
+        nsites = self.get_nsites_from_cif(cif_file)
+        if nsites is None:
+            raise Exception(
+                "cif file is not formatted correctly.\n"
+                "It must contain _cell_formula_units_Z."
+            )
+        atoms_over_nsites = self.parameters.number_of_atoms / nsites
+        if atoms_over_nsites % 2 != 0:
+            raise Exception(
+                "Number of atoms together with crystal structure "
+                "is not supported. The ratio of these two values "
+                "must be an even number."
+            )
+        # matrix which creates supercell
+        transform_ratios = [1, 1, 1]
+        while atoms_over_nsites > 1:
+            for i in range(3):
+                transform_ratios[i] *= 2
+                atoms_over_nsites /= 2
+
+        transformation_matrix = [
+            [transform_ratios[0], 0, 0],
+            [0, transform_ratios[1], 0],
+            [0, 0, transform_ratios[2]],
+        ]
+
+        return transformation_matrix
+
+    @staticmethod
+    def get_nsites_from_cif(cif_file):
+        with open(cif_file, "r") as file:
+            for line in file:
+                if line.startswith("_cell_formula_units_Z"):
+                    return int(line.split()[-1])
+        # returns None if the line isn't found
+        return None

--- a/malada/providers/supercell.py
+++ b/malada/providers/supercell.py
@@ -38,8 +38,14 @@ class SuperCellProvider(Provider):
         cif_file : string
             Path to cif file used for supercell creation.
         """
-        file_name = self.parameters.element + "_" + str(self.parameters.number_of_atoms) \
-                    + "_" + self.parameters.crystal_structure + ".vasp"
+        file_name = (
+            self.parameters.element
+            + "_"
+            + str(self.parameters.number_of_atoms)
+            + "_"
+            + self.parameters.crystal_structure
+            + ".vasp"
+        )
         self.supercell_file = os.path.join(provider_path, file_name)
         if self.external_supercell_file is None:
             try:
@@ -47,18 +53,20 @@ class SuperCellProvider(Provider):
             except FileNotFoundError:
                 self.generate_cif(cif_file)
                 primitive_cell = ase.io.read(cif_file, format="cif")
-            transformation_matrix = structure_to_transformation\
-                                    [self.parameters.crystal_structure]\
-                                    [self.parameters.number_of_atoms]
+            transformation_matrix = structure_to_transformation[
+                self.parameters.crystal_structure
+            ][self.parameters.number_of_atoms]
 
-            super_cell = ase.build.make_supercell(primitive_cell,
-                                                  transformation_matrix)
-            super_cell = self.get_compressed_cell(super_cell,
-                                                  stretch_factor = self.parameters.stretch_factor,
-                                                  density = self.parameters.mass_density,
-                                                  radius = self.parameters.WS_radius)
-            ase.io.write(self.supercell_file,
-                         super_cell, format="vasp", long_format=True)
+            super_cell = ase.build.make_supercell(primitive_cell, transformation_matrix)
+            super_cell = self.get_compressed_cell(
+                super_cell,
+                stretch_factor=self.parameters.stretch_factor,
+                density=self.parameters.mass_density,
+                radius=self.parameters.WS_radius,
+            )
+            ase.io.write(
+                self.supercell_file, super_cell, format="vasp", long_format=True
+            )
         else:
             copyfile(self.external_supercell_file, self.supercell_file)
             print("Getting <<supercell>>.vasp file from disc.")
@@ -71,15 +79,16 @@ class SuperCellProvider(Provider):
         radius=None,
         units_density="g/(cm^3)",
     ):
-
         if sum([stretch_factor is None, density is None, radius is None]) == 3:
             raise ValueError(
                 "At least one of stretch_factor, density and radius must be speficied"
             )
         elif sum([stretch_factor is None, density is None, radius is None]) < 2:
-            print("Warning: More than one of stretch factor, density, "
-                  "and radius is specified.\nRadius takes first priority, "
-                  "then density, finally stretch factor.")
+            print(
+                "Warning: More than one of stretch factor, density, "
+                "and radius is specified.\nRadius takes first priority, "
+                "then density, finally stretch factor."
+            )
         if density is not None:
             density_ambient = SuperCellProvider.get_mass_density(
                 supercell, unit=units_density
@@ -100,20 +109,21 @@ class SuperCellProvider(Provider):
         nr_electrons = 0
         for i in range(0, nr_atoms):
             nr_electrons += supercell[i].number
-        number_density = nr_electrons/volume_atoms
+        number_density = nr_electrons / volume_atoms
         angstrom3_in_m3 = 1 / (m * m * m)
         angstrom3_in_cm3 = angstrom3_in_m3 * 1000000
         if unit == "Angstrom^3":
             return number_density
         elif unit == "cm^3":
-            return number_density/angstrom3_in_cm3
+            return number_density / angstrom3_in_cm3
         else:
             raise Exception("Unit not implemented")
 
     @staticmethod
     def get_wigner_seitz_radius(supercell):
-        number_density = SuperCellProvider.\
-            get_number_density(supercell, unit="Angstrom^3")
+        number_density = SuperCellProvider.get_number_density(
+            supercell, unit="Angstrom^3"
+        )
         rs_angstrom = (3 / (4 * np.pi * number_density)) ** (1 / 3)
         return rs_angstrom / Bohr
 
@@ -127,9 +137,9 @@ class SuperCellProvider(Provider):
         u_angstrom3_in_kg_m3 = kg / (m * m * m)
         u_angstrom3_in_g_cm3 = u_angstrom3_in_kg_m3 * 1000
         if unit == "kg_m^3":
-            return mass_density/u_angstrom3_in_kg_m3
+            return mass_density / u_angstrom3_in_kg_m3
         elif unit == "g/(cm^3)":
-            return mass_density/u_angstrom3_in_g_cm3
+            return mass_density / u_angstrom3_in_g_cm3
         elif unit == "u_Angstrom^3":
             return mass_density
         else:
@@ -137,16 +147,57 @@ class SuperCellProvider(Provider):
 
     def generate_cif(self, cif_file):
         # read in the api key
-        with open(self.parameters.mp_api_file, "r") as f:
-            api_key = f.readlines()[0].strip()
+        try:
+            with open(self.parameters.mp_api_file, "r") as f:
+                api_key = f.readlines()[0].strip()
+        except FileNotFoundError:
+            raise Exception(
+                "File containing materials project API key not found.\n"
+                "If you want to generate structures automatically, please "
+                "register an account on the Materials Project website.\n"
+                "Then save the API key in a file and set the file location "
+                "using parameters.mp_api_file."
+            )
         # initialize materials project api
         mpr = MPRester(api_key)
-        # dictionary relating elements to their MP IDs
-        # TODO: maybe this needs to go elsewhere
-        mat_ids = {"Al": "mp-134", "Be": "mp-87"}
-        structure = mpr.get_structure_by_material_id(mat_ids[self.parameters.element], conventional_unit_cell=True)
-        structure.to(filename = cif_file)
-        
-        
-
-
+        # dictionary relating crystal structures to their space groups
+        # TODO should this be moved elsewhere?
+        lattice_space_groups = {"fcc": 225, "bcc": 229, "hcp": 194}
+        # search materials project database for the desired element
+        structures = mpr.summary.search(
+            chemsys=self.parameters.element,
+            fields=["symmetry", "material_id", "theoretical", "energy_above_hull"],
+        )
+        # narrow down by correct structure
+        structures = list(
+            filter(
+                lambda x: x.symmetry.number
+                == lattice_space_groups[self.parameters.crystal_structure],
+                structures,
+            )
+        )
+        if len(structures) == 0:
+            raise Exception(
+                "No structure found for element "
+                + self.parameters.element
+                + " with crystal structure"
+                + self.parameters.crystal_structure
+                + "\n."
+                + "Please reconsider parameters or provide your own input files."
+            )
+        # narrow down by structures which are experimentally verified
+        structures_expt = list(filter(lambda x: x.theoretical == False, structures))
+        # choose minimal energy structure
+        if len(structures_expt) == 0:
+            best_structure = min(structures, key=lambda x: x.energy_above_hull)
+        elif len(structures_expt) == 1:
+            best_structure = structures_expt[0]
+        elif len(structures_expt) > 1:
+            best_structure = min(structures_expt, key=lambda x: x.energy_above_hull)
+        # get the ID of the best structure
+        best_structure_id = best_structure.material_id
+        structure = mpr.get_structure_by_material_id(
+            best_structure_id, conventional_unit_cell=True
+        )
+        # write to the cif file
+        structure.to(filename=cif_file)

--- a/malada/utils/parameters.py
+++ b/malada/utils/parameters.py
@@ -1,5 +1,6 @@
 """Collection of all parameters for the pipeline."""
 
+import os
 from .slurmparams import SlurmParameters
 
 
@@ -129,6 +130,7 @@ class Parameters:
         self.pseudopotential = {"path": None, "valence_electrons": 0,
                                 "name": None}
         self.run_system = "bash"
+        self.mp_api_file = os.path.expanduser("~") + "/malada/.mp_api/.api_key"
         self.dft_slurm = SlurmParameters()
         self.md_slurm = SlurmParameters()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ ase
 numpy
 scipy
 asap3
+mp-api
+mpcontribs-client


### PR DESCRIPTION
This PR allows users to automatically download a CIF file using the materials project API, just by specifying an element and crystal structure.

First, the database is searched to find all possible combinations of that crystal structure and element. If none are found, an exception is raised. If more than one are found, it first tries to filter by selecting only those structures which are experimentally verified. If there are no experimentally verified structures, or more than one, it selects the structure with minimal energy.

Note: it requires users to register for a materials project account (which is free), and then save their API key somewhere.