### PR TITLE
Fixing compatibility with the new ASE

### DIFF
--- a/malada/providers/dftconvergence.py
+++ b/malada/providers/dftconvergence.py
@@ -144,7 +144,7 @@ class DFTConvergenceProvider(Provider):
                                 "Run scripts created, please run via slurm.\n"
                                 "Quitting now."
                             )
-                            quit()
+                            return
                         else:
                             raise Exception("DFT calculations failed.")
                     if self.converged_cutoff is None:
@@ -199,7 +199,7 @@ class DFTConvergenceProvider(Provider):
                                 "Run scripts created, please run via slurm.\n"
                                 "Quitting now."
                             )
-                            quit()
+                            return
                         else:
                             raise Exception("DFT calculations failed.")
 

--- a/malada/providers/md.py
+++ b/malada/providers/md.py
@@ -126,7 +126,7 @@ class MDProvider(Provider):
                 if self.parameters.run_system == "slurm_creator":
                     print("Created run scripts. Please run via slurm.")
                     print("Quitting...")
-                    quit()
+                    return
             else:
                 folder_to_parse = self.external_run_folder
 

--- a/malada/providers/supercell.py
+++ b/malada/providers/supercell.py
@@ -72,7 +72,6 @@ class SuperCellProvider(Provider):
                 self.supercell_file,
                 super_cell,
                 format="vasp",
-                long_format=True,
             )
         else:
             copyfile(self.external_supercell_file, self.supercell_file)


### PR DESCRIPTION
`long_format=True` option is no longer available for the ASE vasp writer (as of the merge [3155](https://gitlab.com/ase/ase/-/merge_requests/3155) from November 2023). Differences in the produced files seem to be within the round-off error.

In addition, this merge replaces 'quit()' with 'return' in the `dftconvergence` and `md` providers, which seems better suited for production code and Jupyter notebooks.